### PR TITLE
method inUiThread was not working as expected

### DIFF
--- a/video-player-manager/src/main/java/com/volokh/danylo/video_player_manager/ui/MediaPlayerWrapper.java
+++ b/video-player-manager/src/main/java/com/volokh/danylo/video_player_manager/ui/MediaPlayerWrapper.java
@@ -669,6 +669,8 @@ public abstract class MediaPlayerWrapper
     }
 
     private boolean inUiThread() {
-        return Thread.currentThread().getId() == 1;
+//         return Thread.currentThread().getId() == 1;
+        return Looper.myLooper() == Looper.getMainLooper()
+        
     }
 }


### PR DESCRIPTION
App was crashing with RuntimeException("this should be called in Main Thread")
due to method "inUiThread" returning false even though it is running in main thread .
After changing logic to check the main thread app is working fine.